### PR TITLE
Pin botocore version to avoid breaking api changes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     packages=find_packages(exclude=['tests*']),
     package_dir={'botocore_tornado': 'botocore_tornado'},
     include_package_data=True,
-    install_requires=['botocore>=0.93.0',
+    install_requires=['botocore=0.93.0',
                       'tornado>=4.0.0'],
     license=read("LICENSE.txt"),
     classifiers=(


### PR DESCRIPTION
As described in https://github.com/qudos-com/botocore-tornado/issues/2 botocore recently introduced backwards incompatible api changes, resulting e.g. in import errors like:

 import botocore_tornado.session
  File "/usr/lib/python2.7/site-packages/botocore_tornado/session.py", line 2, in <module>
    import botocore_tornado.service
  File "/usr/lib/python2.7/site-packages/botocore_tornado/service.py", line 3, in <module>
    import botocore.service
ImportError: No module named service
